### PR TITLE
Update semver to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ indicatif = "0.15.0"
 fs_extra = "1.1.0"
 console = "0.11"
 dialoguer = "0.6.2"
-semver = "0.10.0"
+semver = "0.11"
 csv = "1.1.3"
 
 [dependencies.reqwest]


### PR DESCRIPTION
Needs #35 to drop the outdated `Cargo.lock`