### PR TITLE
Replaced Configuration constructors with ConfigurationBuilder

### DIFF
--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Instant};
 
 mod config;
 mod monitor;
@@ -14,7 +11,7 @@ mod status;
 
 use crate::load::rayon::{DurationRequestConsumer, Executor, FixedCountRequestConsumer};
 use ::rayon::iter::plumbing::bridge_unindexed;
-pub use config::{Configuration, Monitor, Strategy};
+pub use config::{Configuration, ConfigurationBuilder, Monitor, Strategy};
 pub use indicatif::{MultiProgress, ProgressBar};
 pub use monitor::MonitorThread;
 pub use progress::{use_as_monitor_progress_bar, use_as_status_progress_bar};
@@ -221,7 +218,7 @@ where
     let request_generator = RayonWrapper::from(request_generator);
     println!("Running load using {:?}", config.strategy());
     let mut executor = Executor::new(config.thread_no());
-    let delay = Duration::from_millis(config.step_delay());
+    let delay = config.step_delay();
     let strategy = config.strategy().clone();
     let thread_no = config.thread_no();
     executor.spawn(move || match strategy {

--- a/tests/load.rs
+++ b/tests/load.rs
@@ -1,3 +1,4 @@
+use jortestkit::load::ConfigurationBuilder;
 pub use jortestkit::load::{
     self, Configuration, Id, Monitor, Request, RequestFailure, RequestGenerator, RequestStatus,
     RequestStatusProvider, Response,
@@ -21,35 +22,27 @@ impl RequestGenerator for SampleRequestGenerator {
     }
 
     fn split(self) -> (Self, Option<Self>) {
-        (self.clone(), None)
+        (self, None)
     }
 }
 
 #[test]
 pub fn load_sanity_sync() {
-    let config = Configuration::duration(
-        1,
-        std::time::Duration::from_secs(3),
-        50,
-        None,
-        Monitor::Progress(10),
-        0,
-        1,
-    );
+    let config = ConfigurationBuilder::duration(Duration::from_secs(3))
+        .step_delay(Duration::from_millis(50))
+        .monitor(Monitor::Progress(10))
+        .build();
+
     load::start_sync(SampleRequestGenerator { counter: 1 }, config, "Mock load");
 }
 
 #[test]
 pub fn load_sanity_multi_sync() {
-    let config = Configuration::duration(
-        5,
-        std::time::Duration::from_secs(5),
-        10,
-        None,
-        Monitor::Progress(100),
-        0,
-        1,
-    );
+    let config = ConfigurationBuilder::duration(Duration::from_secs(5))
+        .thread_no(5)
+        .step_delay(Duration::from_millis(10))
+        .monitor(Monitor::Progress(100))
+        .build();
 
     load::start_multi_sync(vec![
         (
@@ -64,7 +57,7 @@ pub fn load_sanity_multi_sync() {
         ),
         (
             SampleRequestGenerator { counter: 1 },
-            config.clone(),
+            config,
             "Mock multi load #3".to_string(),
         ),
     ]);
@@ -87,7 +80,7 @@ impl RequestGenerator for AsyncSampleRequestGenerator {
     }
 
     fn split(self) -> (Self, Option<Self>) {
-        (self.clone(), None)
+        (self, None)
     }
 }
 
@@ -104,15 +97,10 @@ impl RequestStatusProvider for SampleRequestStatusProvider {
 
 #[test]
 pub fn load_sanity_async() {
-    let config = Configuration::duration(
-        1,
-        std::time::Duration::from_secs(3),
-        50,
-        None,
-        Monitor::Progress(10),
-        0,
-        1,
-    );
+    let config = ConfigurationBuilder::duration(Duration::from_secs(3))
+        .step_delay(Duration::from_millis(50))
+        .monitor(Monitor::Progress(10))
+        .build();
     load::start_async(
         AsyncSampleRequestGenerator { counter: 1 },
         SampleRequestStatusProvider,


### PR DESCRIPTION
* Added a `ConfigurationBuilder` structure with 3 constructors – one for each strategy variant.
* Removed `Configuration` constructors.
* Using integer values for timing parameters makes the code on the calling side a bit ambiguous. It's hard to discern whether `step_delay: u64` refers to seconds or milliseconds for example. To make the interface clearer, I've changed some parameter types:
  * `shutdown_grace_period` from `u32` to `Duration`
  * `status_pace` from `u64` to `Duration`
  * `step_delay` from `u64` to `Duration`

Related PRs:
* input-output-hk/jormungandr#3668
* input-output-hk/vit-testing#137
* input-output-hk/vit-servicing-station#186