### PR TITLE
Replace chrono dependency with time 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ serde_json = "1.0"
 rand = "0.8"
 rand_core = "0.5"
 rand_chacha = "0.3"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 humantime = "2.0"
 custom_debug = "0.5"
 thiserror = "1.0"
 sysinfo = { version = "0.14.10" }
 os_info = { version = "3.0.6", default-features = false }
-zip = "0.5.12"
+zip = { version = "0.5.13", default-features = false }
 flate2 = "1.0.16"
 tar = "0.4"
 hex = "0.4"

--- a/src/measurement/attribute/endurance.rs
+++ b/src/measurement/attribute/endurance.rs
@@ -9,10 +9,9 @@ impl From<Duration> for Endurance {
         Endurance(duration)
     }
 }
-#[allow(clippy::from_over_into)]
-impl Into<Duration> for Endurance {
-    fn into(self) -> Duration {
-        self.0
+impl From<Endurance> for Duration {
+    fn from(src: Endurance) -> Self {
+        src.0
     }
 }
 

--- a/src/measurement/benchmark/endurance_benchmark.rs
+++ b/src/measurement/benchmark/endurance_benchmark.rs
@@ -65,7 +65,8 @@ impl EnduranceBenchmarkRun {
 
     pub fn max_endurance_reached(&self) -> bool {
         if let Some(thresholds) = &self.definition.thresholds {
-            self.start_marker.elapsed() > thresholds.max().into()
+            let max: Duration = thresholds.max().into();
+            self.start_marker.elapsed() > max
         } else {
             false
         }

--- a/src/measurement/benchmark/speed_benchmark.rs
+++ b/src/measurement/benchmark/speed_benchmark.rs
@@ -65,7 +65,8 @@ impl SpeedBenchmarkRun {
 
     pub fn timeout_exceeded(&self) -> bool {
         if let Some(thresholds) = &self.definition.thresholds {
-            self.start_marker.elapsed() > thresholds.max().into()
+            let max: Duration = thresholds.max().into();
+            self.start_marker.elapsed() > max
         } else {
             false
         }

--- a/src/measurement/marker/timestamp.rs
+++ b/src/measurement/marker/timestamp.rs
@@ -1,9 +1,12 @@
-use chrono::DateTime;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
 use std::{
     fmt,
     str::FromStr,
     time::{Duration, SystemTime},
 };
+
 #[derive(Clone, Copy)]
 pub struct Timestamp(SystemTime);
 
@@ -40,17 +43,11 @@ impl Into<SystemTime> for Timestamp {
     }
 }
 impl FromStr for Timestamp {
-    type Err = chrono::ParseError;
+    type Err = time::error::Parse;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let dt: DateTime<chrono::FixedOffset> = DateTime::parse_from_rfc3339(s)?;
-        let seconds = dt.timestamp() as u64;
-        let nsecs = dt.timestamp_subsec_nanos();
-
-        let elapsed = Duration::new(seconds, nsecs);
-
-        let time = SystemTime::UNIX_EPOCH.checked_add(elapsed).unwrap();
-
-        Ok(time.into())
+        let dt = OffsetDateTime::parse(s, &Rfc3339)?;
+        Ok(Timestamp(dt.into()))
     }
 }
 


### PR DESCRIPTION
Also disable the unused time feature on zip.
This removes the vulnerabilities reported by audit.